### PR TITLE
Allow defining a logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,24 @@ const createRunner = ChaosRunner.configure({
     },
     {
       // weight: 1, // default value
-      createAttack: () => ({
-        start: () => {
-          /* do a custom attack!*/
-        },
-        stop: () => {
-          /* stop the attack */
-        },
-      }),
+      createAttack: () => {
+        // Use a class for Attacks, as the Runner will take the class name as the attack name
+        // using a plain object will result in the attack name being "Object"
+        class CustomAttack {
+          start() {
+            // do a custom attack!
+          }
+          stop() {
+            // stop the attack
+          }
+        }
+        return new CustomAttack();
+      },
     },
   ],
+
+  // OPTIONAL: define a custom logger, defaults to console methods
+  logger: (level, message, details) => console[level](message, details),
 });
 
 // a new instance of the runner should be created for each possible chaos run
@@ -56,17 +64,18 @@ runner.stop();
 
 ## Runner Arguments
 
-| Parameter         | Type     | Default | Description                                                                          |
-| ----------------- | -------- | ------- | ------------------------------------------------------------------------------------ |
-| `probability`     | `Number` | `1`     | A "global" probability range between 0-1. Defaults to `1` which is 100% probability. |
-| `possibleAttacks` | `Array`  | -       | An array of objects of [possible attacks](#possible-attack) that could be initiated  |
+| Parameter         | Type       | Default                                       | Description                                                                                                                                     |
+| ----------------- | ---------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `probability`     | `Number`   | `1`                                           | A "global" probability range between 0-1. Defaults to `1` which is 100% probability.                                                            |
+| `possibleAttacks` | `Array`    | -                                             | An array of objects of [possible attacks](#possible-attack) that could be initiated                                                             |
+| `logger`          | `Function` | `(level, ...args) => console[level](...args)` | A logger function which is called for significant actions/decisions, such as starting an attack. Set to a no-op (`() => {}`) to disable logging |
 
 ## Possible Attack
 
 | Parameter      | Type       | Default | Description                                                                                         |
 | -------------- | ---------- | ------- | --------------------------------------------------------------------------------------------------- |
 | `weight`       | `Number`   | `1`     | Sets the weighting of an attack vs the other attacks. Default = 1, set to 0 to disable this attack. |
-| `createAttack` | `Function` | -       | Function which returns an attack object exposing a start and stop method.                           |
+| `createAttack` | `Function` | -       | Function which returns an attack class exposing a start and stop method.                            |
 
 ## Probabilities
 

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -17,16 +17,23 @@ const createRunner = ChaosRunner.configure({
     },
     {
       // weight: 1, // default value
-      createAttack: () => ({
-        start: () => {
-          /* do a custom attack!*/
-        },
-        stop: () => {
-          /* stop the attack */
-        },
-      }),
+      createAttack: () => {
+        // Use a class for Attacks, as the Runner will take the class name as the attack name
+        class CustomAttack {
+          start() {
+            // do a custom attack!
+          }
+          stop() {
+            // stop the attack
+          }
+        }
+        return new CustomAttack();
+      },
     },
   ],
+
+  // OPTIONAL: define a custom logger, defaults to console methods
+  logger: (level, message, details) => console[level](message, details),
 });
 
 // a new instance of the runner should be created for each possible chaos run
@@ -42,17 +49,18 @@ runner.stop();
 
 ## Runner Arguments
 
-| Parameter         | Type     | Default | Description                                                                          |
-| ----------------- | -------- | ------- | ------------------------------------------------------------------------------------ |
-| `probability`     | `Number` | `1`     | A "global" probability range between 0-1. Defaults to `1` which is 100% probability. |
-| `possibleAttacks` | `Array`  | -       | An array of objects of [possible attacks](#possible-attack) that could be initiated  |
+| Parameter         | Type       | Default                                       | Description                                                                                                                                     |
+| ----------------- | ---------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `probability`     | `Number`   | `1`                                           | A "global" probability range between 0-1. Defaults to `1` which is 100% probability.                                                            |
+| `possibleAttacks` | `Array`    | -                                             | An array of objects of [possible attacks](#possible-attack) that could be initiated                                                             |
+| `logger`          | `Function` | `(level, ...args) => console[level](...args)` | A logger function which is called for significant actions/decisions, such as starting an attack. Set to a no-op (`() => {}`) to disable logging |
 
 ## Possible Attack
 
 | Parameter      | Type       | Default | Description                                                                                         |
 | -------------- | ---------- | ------- | --------------------------------------------------------------------------------------------------- |
 | `weight`       | `Number`   | `1`     | Sets the weighting of an attack vs the other attacks. Default = 1, set to 0 to disable this attack. |
-| `createAttack` | `Function` | -       | Function which returns an attack object exposing a start and stop method.                           |
+| `createAttack` | `Function` | -       | Function which returns an attack class exposing a start and stop method.                            |
 
 ## Probabilities
 


### PR DESCRIPTION
Closes #8 

Allows passing a very simple function which accepts `level, message, details`, which defaults to using console.log. This should be quite easy to use with any logger, as they all usually expect this format or similar.