### PR TITLE
Switch to using ES6 exports instead of CommonJS style

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ JavaScript Chaos
 ```ts
 import ChaosRunner from '@dazn/chaos-squirrel-runner';
 import CPUAttack from '@dazn/chaos-squirrel-attack-cpu';
+// in ES5/CommonJS
+// const { default: CPUAttack } = require('@dazn/chaos-squirrel-attack-cpu');
 
 const createRunner = ChaosRunner.configure({
   probability: 1,

--- a/packages/attack-cpu-background/src/index.ts
+++ b/packages/attack-cpu-background/src/index.ts
@@ -1,11 +1,11 @@
 import { fork, ChildProcess } from 'child_process';
 
-interface BackgroundCPUAttackOptions {
+export interface BackgroundCPUAttackOptions {
   runTime?: number;
   threads?: number;
 }
 
-class BackgroundCPUAttack {
+export default class BackgroundCPUAttack {
   static configure(
     opts: BackgroundCPUAttackOptions
   ): () => BackgroundCPUAttack {
@@ -43,5 +43,3 @@ class BackgroundCPUAttack {
     });
   }
 }
-
-export = BackgroundCPUAttack;

--- a/packages/attack-cpu/src/index.ts
+++ b/packages/attack-cpu/src/index.ts
@@ -1,9 +1,9 @@
-interface CPUAttackOptions {
+export interface CPUAttackOptions {
   runTime?: number;
   allowLoopEvery?: number;
 }
 
-class CPUAttack {
+export default class CPUAttack {
   static configure(opts: CPUAttackOptions): () => CPUAttack {
     return () => {
       const attack = new CPUAttack(opts);
@@ -58,5 +58,3 @@ class CPUAttack {
     return { until: lastRun ? runUntil : nextTick, lastRun };
   }
 }
-
-export = CPUAttack;

--- a/packages/attack-disk-space/src/index.ts
+++ b/packages/attack-disk-space/src/index.ts
@@ -3,11 +3,11 @@ import { join as pathJoin } from 'path';
 import { tmpdir } from 'os';
 import { spawn } from 'child_process';
 
-interface DiskSpaceAttackOptions {
+export interface DiskSpaceAttackOptions {
   size?: number;
 }
 
-class DiskSpaceAttack {
+export default class DiskSpaceAttack {
   static configure(opts: DiskSpaceAttackOptions): () => DiskSpaceAttack {
     return () => {
       const attack = new DiskSpaceAttack(opts);
@@ -67,5 +67,3 @@ class DiskSpaceAttack {
     }
   }
 }
-
-export = DiskSpaceAttack;

--- a/packages/attack-memory-background/src/index.ts
+++ b/packages/attack-memory-background/src/index.ts
@@ -1,11 +1,11 @@
 import { fork, ChildProcess } from 'child_process';
 import buffer from 'buffer';
 
-interface BackgroundMemoryAttackOptions {
+export interface BackgroundMemoryAttackOptions {
   size?: number;
 }
 
-class BackgroundMemoryAttack {
+export default class BackgroundMemoryAttack {
   static configure(
     opts: BackgroundMemoryAttackOptions
   ): () => BackgroundMemoryAttack {
@@ -35,5 +35,3 @@ class BackgroundMemoryAttack {
     if (this.worker) this.worker.kill();
   }
 }
-
-export = BackgroundMemoryAttack;

--- a/packages/attack-memory/src/index.ts
+++ b/packages/attack-memory/src/index.ts
@@ -2,11 +2,11 @@ import buffer from 'buffer';
 
 const BUF_LENGTH = buffer.constants.MAX_LENGTH;
 
-interface MemoryAttackOptions {
+export interface MemoryAttackOptions {
   size?: number;
 }
 
-class MemoryAttack {
+export default class MemoryAttack {
   static configure(opts: MemoryAttackOptions): () => MemoryAttack {
     return () => {
       const attack = new MemoryAttack(opts);
@@ -35,5 +35,3 @@ class MemoryAttack {
     this.buffers = [];
   }
 }
-
-export = MemoryAttack;

--- a/packages/attack-open-files/src/index.ts
+++ b/packages/attack-open-files/src/index.ts
@@ -2,11 +2,11 @@ import { promises as fs } from 'fs';
 import { join as pathJoin } from 'path';
 import { tmpdir } from 'os';
 
-interface OpenFilesAttackOptions {
+export interface OpenFilesAttackOptions {
   number?: number;
 }
 
-class OpenFilesAttack {
+export default class OpenFilesAttack {
   static configure(opts: OpenFilesAttackOptions): () => OpenFilesAttack {
     return () => {
       const attack = new OpenFilesAttack(opts);
@@ -49,5 +49,3 @@ class OpenFilesAttack {
     return opened;
   }
 }
-
-export = OpenFilesAttack;

--- a/packages/runner-middy/src/index.ts
+++ b/packages/runner-middy/src/index.ts
@@ -2,18 +2,18 @@ import middy from '@middy/core';
 import { Context } from 'aws-lambda';
 import Runner from '@dazn/chaos-squirrel-runner';
 
-interface ChaosContext extends Context {
+export interface ChaosContext extends Context {
   chaosRunner?: Runner;
 }
 
-interface MiddyRunnerOptions {
+export interface MiddyRunnerOptions {
   createRunner: () => Runner;
   wait?: boolean;
 }
 
 type ChaosMiddleware = middy.MiddlewareObject<unknown, unknown, ChaosContext>;
 
-const middleware = ({
+export default ({
   createRunner,
   wait = true,
 }: MiddyRunnerOptions): ChaosMiddleware => {
@@ -40,5 +40,3 @@ const middleware = ({
     },
   };
 };
-
-export = middleware;

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,28 +1,28 @@
 type VoidOrPromise = void | Promise<void>;
 
-interface Attack {
+export interface Attack {
   start: () => VoidOrPromise;
   stop: () => VoidOrPromise;
 }
 
-interface PossibleAttack {
+export interface PossibleAttack {
   weight?: number;
   createAttack: () => Attack;
 }
 
-type LogFn = (
+export type Logger = (
   level: 'debug' | 'info',
   message: string,
   details: Record<string, unknown>
 ) => void;
 
-interface RunnerConfig {
+export interface RunnerConfig {
   probability?: number;
   possibleAttacks: PossibleAttack[];
-  logger?: LogFn;
+  logger?: Logger;
 }
 
-class Runner {
+export default class Runner {
   static configure(opts: RunnerConfig): () => Runner {
     return () => new Runner(opts);
   }
@@ -30,7 +30,7 @@ class Runner {
   probability: number;
   possibleAttacks: PossibleAttack[];
   attack?: Attack;
-  logger: LogFn;
+  logger: Logger;
   private attackStarted?: number;
 
   constructor({
@@ -108,5 +108,3 @@ class Runner {
     );
   }
 }
-
-export = Runner;


### PR DESCRIPTION
Closes #21 

Needed to export an interface as part of another feature, so this became a necessity.