### PR TITLE
feat(attack-memory[-background]): add progressive, stepped memory attack option

### DIFF
--- a/packages/attack-memory-background/README.md
+++ b/packages/attack-memory-background/README.md
@@ -4,18 +4,39 @@ Use lots of memory in a forked process. This will apply memory pressure to your 
 
 ## Usage
 
+Basic memory attack.
+
 ```ts
 import BackgroundMemoryAttack from '@dazn/chaos-squirrel-attack-memory-background';
 
 const createBackgroundMemoryAttack = BackgroundMemoryAttack.configure({
-  // 2gb
-  size: 2000000000,
+  size: 2e9 // ~2gb
 });
 
 const backgroundMemoryAttack = createBackgroundMemoryAttack();
 backgroundMemoryAttack.start();
 
-// 2gb of memory will be used in a forked process
+// ~2gb of memory will be used in a forked process
 
-memoryAttack.stop(); // kills the process
+backgroundMemoryAttack.stop(); // kills the process
+```
+
+Progressive memory attack.
+
+
+```ts
+import BackgroundMemoryAttack from '@dazn/chaos-squirrel-attack-memory-background';
+
+const createBackgroundMemoryAttack = BackgroundMemoryAttack.configure({
+  size: 2e9 // ~2gb
+  stepSize: 2e8, // ~200mb
+  stepTime: 1e3 // 1s
+});
+
+const backgroundMemoryAttack = createBackgroundMemoryAttack();
+backgroundMemoryAttack.start();
+
+// ~2gb of memory will be used in forked processes, starting from 0gb & increasing by ~200mb every 1s
+
+backgroundMemoryAttack.stop(); // kills the processes
 ```

--- a/packages/attack-memory-background/src/fork.test.ts
+++ b/packages/attack-memory-background/src/fork.test.ts
@@ -15,4 +15,19 @@ describe('when a message is received', () => {
     expect(MemoryAttack.prototype.start).toHaveBeenCalledTimes(1);
     expect(process.send).toHaveBeenCalledTimes(1);
   });
+
+  it('starts a memory attack with progressive options', () => {
+    jest.spyOn(process, 'send');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    process.emit('message', { size: 5, stepSize: 1, stepTime: 10 });
+    expect(MemoryAttack).toHaveBeenCalledTimes(1);
+    expect(MemoryAttack).toHaveBeenCalledWith({
+      size: 5,
+      stepSize: 1,
+      stepTime: 10,
+    });
+    expect(MemoryAttack.prototype.start).toHaveBeenCalledTimes(1);
+    expect(process.send).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/attack-memory-background/src/fork.ts
+++ b/packages/attack-memory-background/src/fork.ts
@@ -1,8 +1,16 @@
 import MemoryAttack from '@dazn/chaos-squirrel-attack-memory';
 
-process.on('message', ({ size }: { size: number }) => {
+interface Message {
+  size: number;
+  stepSize?: number;
+  stepTime?: number;
+}
+
+process.on('message', ({ size, stepSize, stepTime }: Message) => {
   const attack = new MemoryAttack({
     size,
+    stepSize,
+    stepTime,
   });
   attack.start();
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/attack-memory/README.md
+++ b/packages/attack-memory/README.md
@@ -1,21 +1,41 @@
 # @dazn/chaos-squirrel-attack-memory
 
-Chaos Squirrel attack to fill memory
+Chaos Squirrel attack to fill memory instantly, or increasing memory usage over time.
 
 ## Usage
+
+Basic memory attack.
 
 ```ts
 import MemoryAttack from '@dazn/chaos-squirrel-attack-memory';
 
 const createMemoryAttack = MemoryAttack.configure({
-  // 2gb
-  size: 2000000000,
+  size: 2e9 // ~2gb
 });
 
 const memoryAttack = createMemoryAttack();
 memoryAttack.start();
 
-// 2gb of memory will be used
+// ~2gb of memory will be used
+
+memoryAttack.stop(); // removes references to memory to allow GC to collect it
+```
+
+Progressive memory attack.
+
+```ts
+import MemoryAttack from '@dazn/chaos-squirrel-attack-memory';
+
+const createMemoryAttack = MemoryAttack.configure({
+  size: 2e9, // ~2gb
+  stepSize: 2e8, // ~200mb
+  stepTime: 1e3 // 1s
+});
+
+const memoryAttack = createMemoryAttack();
+memoryAttack.start();
+
+// ~2gb of memory will be used, starting from 0gb & increasing by ~200mb every 1s
 
 memoryAttack.stop(); // removes references to memory to allow GC to collect it
 ```

--- a/packages/attack-memory/src/index.test.ts
+++ b/packages/attack-memory/src/index.test.ts
@@ -1,5 +1,5 @@
 import MemoryAttack from './';
-import buffer from 'buffer';
+import * as buffer from 'buffer';
 
 describe('when provided a small buffer size', () => {
   it('creates a small buffer', () => {
@@ -36,6 +36,39 @@ describe('when given lengths larger than the max buffer length', () => {
     expect(Buffer.byteLength(attack.buffers[1])).toBe(1);
     attack.stop();
     expect(attack.buffers).toHaveLength(0);
+  });
+});
+
+describe('when given progressive attack options', () => {
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+
+  it('progressively allocates memory', () => {
+    const attack = new MemoryAttack({
+      size: 20,
+      stepSize: 10,
+      stepTime: 100,
+    });
+    attack.start();
+
+    expect(setInterval).toHaveBeenCalled();
+
+    expect(attack.buffers).toHaveLength(1);
+    expect(Buffer.byteLength(attack.buffers[0])).toBe(10);
+
+    jest.advanceTimersByTime(100);
+
+    expect(attack.buffers).toHaveLength(2);
+    expect(Buffer.byteLength(attack.buffers[0])).toBe(10);
+
+    jest.advanceTimersByTime(100);
+
+    expect(attack.buffers).toHaveLength(2);
+
+    attack.stop();
+
+    expect(attack.buffers).toHaveLength(0);
+    expect(clearInterval).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
### Description

* Add progressive option to memory attack (& background version).
  * Allows ratcheting up of memory usage to emulate behaviour like a memory leak etc.
  * Configurable time steps.
  * Configurable memory increase steps.
  * Stops increasing when hits specified memory attack max limit.

### Checklist

- [x] :eyes: I have self-reviewed my PR, leaving comments on any changes which may trigger a discussion
- [x] :hammer: I have tested my changes
- [x] :pencil2: I have updated any relevant documentation
